### PR TITLE
remove trawler's trust from fish tracking

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/trawling/FishCaughtTracker.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/trawling/FishCaughtTracker.java
@@ -73,10 +73,11 @@ public class FishCaughtTracker implements PluginLifecycleComponent {
             return;
         }
 
-        if (message.equals("Trawler's trust: You catch an additional fish.")) {
-            addFish(message, 1, lastFishCaught, "Trawler's trust");
-            return;
-        }
+		// Seems to be bugged in-game or the message indicates the previous catch benefited from the keg
+//        if (message.equals("Trawler's trust: You catch an additional fish.")) {
+//            addFish(message, 1, lastFishCaught, "Trawler's trust");
+//            return;
+//        }
 
         Matcher matcher = CATCH_FISH_REGEX.matcher(message);
         if (!matcher.find()) {


### PR DESCRIPTION
I've noticed this discrepancy in the net count twice now. I believe it is due to trawler's trust not actually adding any fish to the net.

The first time I noticed it, the trawler's message proc'd when the net was empty and it added a blank line to the overlay panel (since lastFish string was null), but didn't add any fish to the net.

The second time I took screenshots:

<img width="868" height="496" alt="1" src="https://github.com/user-attachments/assets/a038a3c5-b912-4851-bf1b-d2d877aa11fc" />
<img width="925" height="827" alt="2" src="https://github.com/user-attachments/assets/965d32c0-c4aa-49f5-9499-3b5c408d8a4a" />

My theory is the message just indicates the previous catch benefited from trawler's trust; though it doesn't explain why it proc'd when my net was empty, but that might be a jagex bug. Either way test it yourself too.