### PR TITLE
simpler way to check net capacity

### DIFF
--- a/src/main/java/com/duckblade/osrs/sailing/features/trawling/NetDepthButtonHighlighter.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/trawling/NetDepthButtonHighlighter.java
@@ -200,7 +200,7 @@ public class NetDepthButtonHighlighter extends Overlay
 
     private boolean canHighlightButtons() {
         Boat boat = boatTracker.getBoat();
-        if (boat == null || boat.getNetTiers().isEmpty()) {
+        if (boat == null || boat.getFishingNets().isEmpty()) {
             return false;
         }
 

--- a/src/main/java/com/duckblade/osrs/sailing/features/trawling/ShoalPathOverlay.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/trawling/ShoalPathOverlay.java
@@ -77,7 +77,7 @@ public class ShoalPathOverlay extends Overlay implements PluginLifecycleComponen
 		if (!SailingUtil.isSailing(client)) {
 			return null;
 		}
-		if (boatTracker.getBoat() == null || boatTracker.getBoat().getNetTiers().isEmpty()) {
+		if (boatTracker.getBoat() == null || boatTracker.getBoat().getFishingNets().isEmpty()) {
 			return null;
 		}
 

--- a/src/main/java/com/duckblade/osrs/sailing/features/trawling/ShoalTracker.java
+++ b/src/main/java/com/duckblade/osrs/sailing/features/trawling/ShoalTracker.java
@@ -213,7 +213,7 @@ public class ShoalTracker implements PluginLifecycleComponent {
 	private void checkDepthNotification()
 	{
 		Boat boat = boatTracker.getBoat();
-		if (boat == null || boat.getNetTiers().isEmpty()) {
+		if (boat == null || boat.getFishingNets().isEmpty()) {
 			return;
 		}
 		notifier.notify(config.notifyDepthChange(), "Shoal depth changed");

--- a/src/main/java/com/duckblade/osrs/sailing/model/Boat.java
+++ b/src/main/java/com/duckblade/osrs/sailing/model/Boat.java
@@ -128,17 +128,7 @@ public class Boat
 
     public int getNetCapacity()
     {
-        int totalCapacity = 0;
-        List<FishingNetTier> netTiers = getNetTiers();
-        SizeClass sizeClass = getSizeClass();
-        for (FishingNetTier netTier : netTiers)
-        {
-            if (netTier != null)
-            {
-                totalCapacity += netTier.getCapacity();
-            }
-        }
-        return totalCapacity;
+        return fishingNets.size() * 125;
     }
 
 	public int getSpeedBoostDuration()


### PR DESCRIPTION
Also, if you didn't want to use BoatTracker at all you could use these two varbits, which will have a non-zero value when a net is present in their respective hotspot locations.

```
VarbitID.SAILING_SIDEPANEL_BOAT_TRAWLING_NET_0_HOTSPOT_ID
VarbitID.SAILING_SIDEPANEL_BOAT_TRAWLING_NET_1_HOTSPOT_ID
```